### PR TITLE
fix(include file): use original name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,5 +19,5 @@ const router = new VueRouter({
 configRouter(router)
 
 // boostrap the app
-const App = Vue.extend(require('./app.vue'))
+const App = Vue.extend(require('./App.vue'))
 router.start(App, '#app')


### PR DESCRIPTION
when run npm build got an error (looks like depends on OS):

```
Module not found: Error: Cannot resolve 'file' or 'directory' ./app.vue 
```

