### PR TITLE
Fix stacked modals

### DIFF
--- a/packages/vuikit/src/components/modal/core.js
+++ b/packages/vuikit/src/components/modal/core.js
@@ -19,6 +19,11 @@ export default {
       this.$emit(TOGGLE, false)
     }
   },
+  mounted () {
+    // append modal at $root as the styles
+    // could be scoped to the app dom
+    this.$nextTick(() => this.$root.$el.appendChild(this.$el))
+  },
   beforeDestroy () {
     // if a modal is destroyed before being closed
     if (this.$el.parentNode) {

--- a/packages/vuikit/src/components/modal/core.js
+++ b/packages/vuikit/src/components/modal/core.js
@@ -19,11 +19,6 @@ export default {
       this.$emit(TOGGLE, false)
     }
   },
-  mounted () {
-    // append modal at $root as the styles
-    // could be scoped to the app dom
-    this.$nextTick(() => this.$root.$el.appendChild(this.$el))
-  },
   beforeDestroy () {
     // if a modal is destroyed before being closed
     if (this.$el.parentNode) {

--- a/packages/vuikit/src/components/modal/transition.js
+++ b/packages/vuikit/src/components/modal/transition.js
@@ -24,7 +24,7 @@ export default {
           const prev = active !== modal && active
 
           // if active modal exist, first close it
-          if (prev && !modal.stacked) {
+          if (prev && !modal.stack) {
             prev.hide()
 
             // once prev modal is closed open the current one

--- a/packages/vuikit/src/components/modal/transition.js
+++ b/packages/vuikit/src/components/modal/transition.js
@@ -63,6 +63,10 @@ export default {
     }
 
     function doEnter (el, done) {
+      // append modal at $root as the styles
+      // could be scoped to the app dom
+      // re-append every time entering so it appears on top
+      modal.$root.$el.appendChild(el)
       // redraw workaround, necessary so the browser
       // doesn't try to apply it all in one step, not
       // giving enough time for the transition to init


### PR DESCRIPTION
First of all congrats on 0.8.0! The package and the website 👍 

I found a little bug with the stacked modals.

Edit:

I also found a bug where when a modal higher in the dom was shown behind the previously opened modal because they get added to the root when created.
The change re-appends them to the root on opening the modal.