### PR TITLE
Added the possibility to set a table title class per column

### DIFF
--- a/packages/vuikit/src/library/table/components/table--column-select.js
+++ b/packages/vuikit/src/library/table/components/table--column-select.js
@@ -13,6 +13,9 @@ export default {
     cellClass: {
       type: String
     },
+    titleClass: {
+      type: String
+    },
     headless: {
       type: Boolean,
       default: false
@@ -39,7 +42,10 @@ export default {
 
     return h(ElementTableTh, mergeData(data, {
       props: { shrinked: true },
-      class: 'vk-table-column-select'
+      class: [
+        'vk-table-column-select',
+        props.titleClass
+      ]
     }), [ content ])
   },
   cellRender (h, ctx) {

--- a/packages/vuikit/src/library/table/components/table--column.js
+++ b/packages/vuikit/src/library/table/components/table--column.js
@@ -10,7 +10,8 @@ export default {
   props: assign({}, ElementTableTh.props, ElementTableTd.props, {
     cell: String,
     title: String,
-    cellClass: String
+    cellClass: String,
+    titleClass: String
   }),
   render (h, { data, props, slots }) {
     // IMPORTANT: don't remove or change, is the
@@ -21,7 +22,10 @@ export default {
   headRender (h, { data, props }) {
     return h(ElementTableTh, mergeData({}, data, {
       props,
-      class: 'vk-table-column'
+      class: [
+        'vk-table-column',
+        props.titleClass
+      ]
     }), props.title)
   },
   cellRender (h, ctx) {


### PR DESCRIPTION
I do not know if you didn't add the possibility to add style classes to the title of a column in the table component but we did use the feature in previous versions of vuikit 😃 

For instance when align the column to the right we set the cell and the title classes to `uk-text-right`. 