### PR TITLE
Show the modal body slot only when the body is used

### DIFF
--- a/packages/vuikit/src/library/modal/components/modal.js
+++ b/packages/vuikit/src/library/modal/components/modal.js
@@ -93,7 +93,7 @@ export default {
         this.$slots.header && h(ElementModalHeader, this.$slots.header),
 
         // body
-        h(ElementModalBody, {
+        this.$slots.default && h(ElementModalBody, {
           directives: this.overflowAuto
             ? [{ name: 'vk-modal-overflow-auto' }]
             : []


### PR DESCRIPTION
I was using the dialog slot and noticed that the body was present in the modal:

```html
<div class="uk-modal-dialog">
  <!-- Inside the dialog slot -->
  <something></something>
  <!-- End dialog slot -->
  <!-- Now always present -->
  <div class="uk-modal-body"></div>
</div>
```

I've added a check for the display of the body.