### PR TITLE
Remove unwanted modal classes

### DIFF
--- a/packages/vuikit/src/library/modal/components/modal-full.js
+++ b/packages/vuikit/src/library/modal/components/modal-full.js
@@ -33,7 +33,6 @@ export default {
 
     const modal = h(ElementModalFull, def, [
       h(ElementModalDialog, {
-        class: 'uk-flex uk-flex-center uk-flex-middle',
         directives: [{
           name: 'vk-height-viewport'
         }]


### PR DESCRIPTION
Full modal adds additional classes to the `modal-dialog` which are not needed:

```html
<div class="uk-modal-dialog uk-flex uk-flex-center uk-flex-middle"></div>
```