### PR TITLE
fix tabs href

### DIFF
--- a/packages/vuikit/src/library/tabs/elements/tabs--item.js
+++ b/packages/vuikit/src/library/tabs/elements/tabs--item.js
@@ -29,7 +29,10 @@ export default {
         'uk-disabled': disabled
       }
     }), [
-      h('a', { on: listeners }, [
+      h('a', {
+        on: listeners,
+        href: '#'
+      }, [
         title,
         icon && h(ElementIcon, {
           class: 'uk-margin-small-left'


### PR DESCRIPTION
Tabs should be focusable so that they represent in tab order.
And unless they have a href they won't be focusable.
As they are in https://getuikit.com/docs/tab .

(please note I have not tested this PR)